### PR TITLE
Add case-mapping command

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -120,6 +120,13 @@ to codepoint. When codepoints are mapped according to this table, then case
 differences (according to Unicode) are eliminated.
 ";
 
+const ABOUT_CASE_MAPPING: &'static str = "\
+case-mapping emits three tables that map code points to their lowercase,
+uppercase, and titlecase equivalents. This is includes simple
+(single codepoint) mappings from UnicodeData.txt as well as multi-codepoint
+unconditional mappings from SpecialCasing.txt.
+";
+
 const ABOUT_GRAPHEME_CLUSTER_BREAK: &'static str = "\
 grapheme-cluster-break emits the table of property values and their
 corresponding codepoints for the Grapheme_Cluster_Break property.
@@ -406,6 +413,15 @@ pub fn app() -> App<'static, 'static> {
              .long("all-pairs")
              .help("Emit a table where each codepoint includes all possible \
                     Simple mappings."));
+    let cmd_case_mapping = SubCommand::with_name("case-mapping")
+        .author(crate_authors!())
+        .version(crate_version!())
+        .template(TEMPLATE_SUB)
+        .about("Create single and multi-codepoint case mapping tables.")
+        .before_help(ABOUT_CASE_MAPPING)
+        .arg(flag_name("CASE_MAPPING"))
+        .arg(ucd_dir.clone())
+        .arg(flag_chars.clone());
     let cmd_grapheme_cluster_break =
         SubCommand::with_name("grapheme-cluster-break")
         .author(crate_authors!())
@@ -521,6 +537,7 @@ pub fn app() -> App<'static, 'static> {
         .subcommand(cmd_property_names)
         .subcommand(cmd_property_values)
         .subcommand(cmd_case_folding_simple)
+        .subcommand(cmd_case_mapping)
         .subcommand(cmd_grapheme_cluster_break)
         .subcommand(cmd_word_break)
         .subcommand(cmd_sentence_break)

--- a/src/case_mapping.rs
+++ b/src/case_mapping.rs
@@ -1,0 +1,70 @@
+use std::collections::BTreeMap;
+
+use ucd_parse::{self, SpecialCaseMapping, UnicodeData, UnicodeDataExpander};
+
+use args::ArgMatches;
+use error::Result;
+
+pub fn command(args: ArgMatches) -> Result<()> {
+    let dir = args.ucd_dir()?;
+    let unicode_data: Vec<UnicodeData> = ucd_parse::parse(dir)?;
+    let special_casing: Vec<SpecialCaseMapping> = ucd_parse::parse(dir)?;
+    let expanded: Vec<_> = UnicodeDataExpander::new(unicode_data).collect();
+
+    // Collect the mappings
+    let mut lowercase = BTreeMap::new();
+    let mut uppercase = BTreeMap::new();
+    let mut titlecase = BTreeMap::new();
+    for row in expanded {
+        if let Some(lower) = row.simple_lowercase_mapping {
+            if row.codepoint.value() != lower.value() {
+                lowercase.insert(row.codepoint.value(), vec![lower.value()]);
+            }
+        }
+        if let Some(upper) = row.simple_uppercase_mapping {
+            if row.codepoint.value() != upper.value() {
+                uppercase.insert(row.codepoint.value(), vec![upper.value()]);
+            }
+        }
+        if let Some(title) = row.simple_titlecase_mapping {
+            if row.codepoint.value() != title.value() {
+                titlecase.insert(row.codepoint.value(), vec![title.value()]);
+            }
+        }
+    }
+
+    // Add unconditional mappings from SpecialCasing.txt
+    for row in special_casing {
+        if !row.conditions.is_empty() {
+            // Skip conditional mappings
+            continue;
+        }
+
+        // Only add if the mapping is not empty and does not map to itself
+        if !row.lowercase.is_empty() && row.lowercase != &[row.codepoint.value()] {
+            lowercase.insert(
+                row.codepoint.value(),
+                row.lowercase.iter().map(|cp| cp.value()).collect(),
+            );
+        }
+        if !row.uppercase.is_empty() && row.uppercase != &[row.codepoint.value()] {
+            uppercase.insert(
+                row.codepoint.value(),
+                row.uppercase.iter().map(|cp| cp.value()).collect(),
+            );
+        }
+        if !row.titlecase.is_empty() && row.titlecase != &[row.codepoint.value()] {
+            titlecase.insert(
+                row.codepoint.value(),
+                row.titlecase.iter().map(|cp| cp.value()).collect(),
+            );
+        }
+    }
+
+    let mut wtr = args.writer("case_mapping")?;
+    wtr.codepoint_to_codepoints(&(args.name().to_owned() + "_LOWERCASE"), &lowercase)?;
+    wtr.codepoint_to_codepoints(&(args.name().to_owned() + "_UPPERCASE"), &uppercase)?;
+    wtr.codepoint_to_codepoints(&(args.name().to_owned() + "_TITLECASE"), &titlecase)?;
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,7 @@ mod writer;
 
 mod age;
 mod case_folding;
+mod case_mapping;
 mod general_category;
 mod brk;
 mod jamo_short_name;
@@ -82,6 +83,9 @@ fn run() -> Result<()> {
         }
         ("case-folding-simple", Some(m)) => {
             case_folding::command(ArgMatches::new(m))
+        }
+        ("case-mapping", Some(m)) => {
+            case_mapping::command(ArgMatches::new(m))
         }
         ("grapheme-cluster-break", Some(m)) => {
             brk::grapheme_cluster(ArgMatches::new(m))


### PR DESCRIPTION
`case-mapping` emits three tables that map code points to their lowercase, uppercase, and titlecase equivalents. This is includes simple (single codepoint) mappings from `UnicodeData.txt` as well as multi-codepoint unconditional mappings from `SpecialCasing.txt`.
