### PR TITLE
Add support for generating Joining_Type tables

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -52,6 +52,11 @@ script-extension produces one table of Unicode codepoint ranges for each
 possible Script_Extension value.
 ";
 
+const ABOUT_JOINING_TYPE: &'static str = "\
+joining-type produces one table of Unicode codepoint ranges for each
+possible Joining_Type value.
+";
+
 const ABOUT_AGE: &'static str = "\
 age produces a table for each discrete Unicode age. Each table includes the
 codepoints that were added for that age. Tables can be emitted as a sorted
@@ -264,6 +269,23 @@ pub fn app() -> App<'static, 'static> {
             .long("list-script-extensions")
             .help("List all of the script extension names with \
                    abbreviations."));
+    let cmd_joining_type = SubCommand::with_name("joining-type")
+        .author(crate_authors!())
+        .version(crate_version!())
+        .template(TEMPLATE_SUB)
+        .about("Create the Joining_Type property tables.")
+        .before_help(ABOUT_JOINING_TYPE)
+        .arg(ucd_dir.clone())
+        .arg(flag_fst_dir.clone())
+        .arg(flag_name("JOINING_TYPE"))
+        .arg(flag_chars.clone())
+        .arg(flag_trie_set.clone())
+        .arg(Arg::with_name("enum")
+            .long("enum")
+            .help("Emit a single table that maps codepoints to joining type."))
+        .arg(Arg::with_name("rust-enum")
+            .long("rust-enum")
+            .help("Emit a Rust enum and a table that maps codepoints to joining type."));
     let cmd_age = SubCommand::with_name("age")
         .author(crate_authors!())
         .version(crate_version!())
@@ -522,6 +544,7 @@ pub fn app() -> App<'static, 'static> {
         .subcommand(cmd_general_category)
         .subcommand(cmd_script)
         .subcommand(cmd_script_extension)
+        .subcommand(cmd_joining_type)
         .subcommand(cmd_age)
         .subcommand(cmd_prop_bool)
         .subcommand(cmd_perl_word)

--- a/src/general_category.rs
+++ b/src/general_category.rs
@@ -76,7 +76,7 @@ pub fn expand_into_categories(unexpanded: Vec<UnicodeData>, propvals: &PropertyV
         .canonical("gc", "unassigned")?
         .to_string();
     bycat.insert(unassigned_name.clone(), BTreeSet::new());
-    for cp in 0..(0x10FFFF + 1) {
+    for cp in 0..=0x10FFFF {
         if !assigned.contains(&cp) {
             bycat.get_mut(&unassigned_name).unwrap().insert(cp);
         }

--- a/src/general_category.rs
+++ b/src/general_category.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 
-use ucd_parse::{self, UnicodeDataExpander};
+use ucd_parse::{self, UnicodeDataExpander, UnicodeData};
 
 use args::ArgMatches;
 use error::Result;
@@ -18,32 +18,8 @@ pub fn command(args: ArgMatches) -> Result<()> {
         return print_property_values(&propvals, "General_Category");
     }
 
-    // Expand all of our UnicodeData rows. This results in one big list of
-    // all assigned codepoints.
-    let rows: Vec<_> = UnicodeDataExpander::new(unexpanded).collect();
+    let mut bycat = expand_into_categories(unexpanded, &propvals)?;
 
-    // Collect each general category into an ordered set.
-    let mut bycat: BTreeMap<String, BTreeSet<u32>> = BTreeMap::new();
-    let mut assigned = BTreeSet::new();
-    for row in rows {
-        assigned.insert(row.codepoint.value());
-        let gc = propvals
-            .canonical("gc", &row.general_category)?
-            .to_string();
-        bycat.entry(gc)
-            .or_insert(BTreeSet::new())
-            .insert(row.codepoint.value());
-    }
-    // As a special case, collect all unassigned codepoints.
-    let unassigned_name = propvals
-        .canonical("gc", "unassigned")?
-        .to_string();
-    bycat.insert(unassigned_name.clone(), BTreeSet::new());
-    for cp in 0..(0x10FFFF + 1) {
-        if !assigned.contains(&cp) {
-            bycat.get_mut(&unassigned_name).unwrap().insert(cp);
-        }
-    }
     // As another special case, collect all "related" groups of categories.
     // But don't do this when printing an enumeration, because in an
     // enumeration each codepoint should belong to exactly one category, which
@@ -75,6 +51,38 @@ pub fn command(args: ArgMatches) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Expand a list of UnicodeData rows and group by category.
+pub fn expand_into_categories(unexpanded: Vec<UnicodeData>, propvals: &PropertyValues) -> Result<BTreeMap<String, BTreeSet<u32>>> {
+    // Expand all of our UnicodeData rows. This results in one big list of
+    // all assigned codepoints.
+    let rows: Vec<_> = UnicodeDataExpander::new(unexpanded).collect();
+
+    // Collect each general category into an ordered set.
+    let mut bycat: BTreeMap<String, BTreeSet<u32>> = BTreeMap::new();
+    let mut assigned = BTreeSet::new();
+    for row in rows {
+        assigned.insert(row.codepoint.value());
+        let gc = propvals
+            .canonical("gc", &row.general_category)?
+            .to_string();
+        bycat.entry(gc)
+            .or_insert(BTreeSet::new())
+            .insert(row.codepoint.value());
+    }
+    // As a special case, collect all unassigned codepoints.
+    let unassigned_name = propvals
+        .canonical("gc", "unassigned")?
+        .to_string();
+    bycat.insert(unassigned_name.clone(), BTreeSet::new());
+    for cp in 0..(0x10FFFF + 1) {
+        if !assigned.contains(&cp) {
+            bycat.get_mut(&unassigned_name).unwrap().insert(cp);
+        }
+    }
+
+    Ok(bycat)
 }
 
 /// Related returns a set of sets of codepoints corresponding to the "related"

--- a/src/joining_type.rs
+++ b/src/joining_type.rs
@@ -1,0 +1,74 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use ucd_parse::{self, ArabicShaping};
+
+use args::ArgMatches;
+use error::{Error, Result};
+use general_category;
+use util::PropertyValues;
+
+pub fn command(args: ArgMatches) -> Result<()> {
+    let dir = args.ucd_dir()?;
+    let propvals = PropertyValues::from_ucd_dir(&dir)?;
+    let rows: Vec<ArabicShaping> = ucd_parse::parse(&dir)?;
+    let unexpanded_gc = ucd_parse::parse(&dir)?;
+    let gc = general_category::expand_into_categories(unexpanded_gc, &propvals)?;
+
+    // Collect each joining type into an ordered set.
+    let mut by_type: BTreeMap<String, BTreeSet<u32>> = BTreeMap::new();
+    let mut assigned = BTreeSet::new();
+    for row in rows {
+        assigned.insert(row.codepoint.value());
+        let jt = propvals.canonical("jt", &row.joining_type)?.to_string();
+        by_type
+            .entry(jt)
+            .or_insert(BTreeSet::new())
+            .insert(row.codepoint.value());
+    }
+    // Process the codepoints that are not listed as per the note in ArabicShaping.txt:
+    //
+    // Note: Code points that are not explicitly listed in this file are
+    // either of joining type T or U:
+    //
+    // - Those that are not explicitly listed and that are of General Category Mn, Me, or Cf
+    //   have joining type T.
+    // - All others not explicitly listed have joining type U.
+    let transparent_name = propvals.canonical("jt", "transparent")?;
+    let non_joining_name = propvals.canonical("jt", "non_joining")?;
+    let transparent_categories = ["Mn", "Me", "Cf"]
+        .iter()
+        .map(|cat| {
+            propvals.canonical("gc", cat).and_then(|name| {
+                gc.get(&name).ok_or_else(|| {
+                    Error::Other(format!("Unable to find general category '{}'", name))
+                })
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    for cp in 0..(0x10FFFF + 1) {
+        if !assigned.contains(&cp) {
+            // See if the code point is in any of the general categories that map to
+            // the Transparent joining type. Otherwise add to the Non_Joining type.
+            if transparent_categories.iter().any(|cat| cat.contains(&cp)) {
+                by_type.get_mut(&transparent_name).unwrap().insert(cp);
+            } else {
+                by_type.get_mut(&non_joining_name).unwrap().insert(cp);
+            }
+        }
+    }
+
+    let mut wtr = args.writer("joining_type")?;
+    if args.is_present("enum") {
+        wtr.ranges_to_enum(args.name(), &by_type)?;
+    } else if args.is_present("rust-enum") {
+        let variants = by_type.keys().map(String::as_str).collect::<Vec<_>>();
+        wtr.ranges_to_rust_enum(args.name(), &variants, &by_type)?;
+    } else {
+        wtr.names(by_type.keys())?;
+        for (name, set) in by_type {
+            wtr.ranges(&name, &set)?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/joining_type.rs
+++ b/src/joining_type.rs
@@ -45,7 +45,7 @@ pub fn command(args: ArgMatches) -> Result<()> {
             })
         })
         .collect::<Result<Vec<_>>>()?;
-    for cp in 0..(0x10FFFF + 1) {
+    for cp in 0..=0x10FFFF {
         if !assigned.contains(&cp) {
             // See if the code point is in any of the general categories that map to
             // the Transparent joining type. Otherwise add to the Non_Joining type.

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod case_folding;
 mod general_category;
 mod brk;
 mod jamo_short_name;
+mod joining_type;
 mod names;
 mod property_bool;
 mod regex;
@@ -70,6 +71,9 @@ fn run() -> Result<()> {
         }
         ("jamo-short-name", Some(m)) => {
             jamo_short_name::command(ArgMatches::new(m))
+        }
+        ("joining-type", Some(m)) => {
+            joining_type::command(ArgMatches::new(m))
         }
         ("names", Some(m)) => {
             names::command(ArgMatches::new(m))


### PR DESCRIPTION
Adds `joining-type` command. Sample output:

```rust
// DO NOT EDIT THIS FILE. IT WAS AUTOMATICALLY GENERATED BY:
//
//  ucd-generate joining-type --rust-enum /home/wmoore/Downloads/ucd-12.1
//
// ucd-generate is available on crates.io.

#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
pub enum JoiningType {
  DualJoining, JoinCausing, LeftJoining, NonJoining, RightJoining,
  Transparent,
}

pub const JOINING_TYPE: &'static [(u32, u32, JoiningType)] = &[
  (0, 172, JoiningType::NonJoining), (173, 173, JoiningType::Transparent),
  (174, 767, JoiningType::NonJoining), (768, 879, JoiningType::Transparent),
  (880, 1154, JoiningType::NonJoining),
  (1155, 1161, JoiningType::Transparent),
  (1162, 1424, JoiningType::NonJoining),
  (1425, 1469, JoiningType::Transparent),
  ⋮
];
```