### PR TITLE
Add bidi-mirroring-glyph sub-command

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -58,6 +58,12 @@ codepoints that were added for that age. Tables can be emitted as a sorted
 sequence of ranges, an FST or a trie.
 ";
 
+const ABOUT_BIDI_MIRRORING_GLYPH: &'static str = "\
+bidi-mirroring-glyph produces a table that maps codepoints that have the
+Bidi_Mirrored=Yes property to another codepoint that typically has a glyph that
+is the mirror image of the original codepoint's glyph.
+";
+
 const ABOUT_PROP_BOOL: &'static str = "\
 property-bool produces possibly many tables for boolean properties. Tables can
 be emitted as a sorted sequence of ranges, an FST or a trie.
@@ -175,6 +181,20 @@ pub fn app() -> App<'static, 'static> {
         .help("Directory containing the Unicode character database files.");
 
     // Subcommands.
+    let cmd_bidi_mirroring_glyph = SubCommand::with_name("bidi-mirroring-glyph")
+        .author(crate_authors!())
+        .version(crate_version!())
+        .template(TEMPLATE_SUB)
+        .about("Create Unicode Bidi Mirroring Glyph table.")
+        .before_help(ABOUT_BIDI_MIRRORING_GLYPH)
+        .arg(ucd_dir.clone())
+        .arg(flag_fst_dir.clone())
+        .arg(flag_name("BIDI_MIRRORING_GLYPH"))
+        .arg(flag_chars.clone())
+        .arg(flag_trie_set.clone())
+        .arg(Arg::with_name("rust-match")
+            .long("rust-match")
+            .help("Emit a function that uses a match to map between codepoints."));
     let cmd_general_category = SubCommand::with_name("general-category")
         .author(crate_authors!())
         .version(crate_version!())
@@ -514,6 +534,7 @@ pub fn app() -> App<'static, 'static> {
         .subcommand(cmd_script)
         .subcommand(cmd_script_extension)
         .subcommand(cmd_age)
+        .subcommand(cmd_bidi_mirroring_glyph)
         .subcommand(cmd_prop_bool)
         .subcommand(cmd_perl_word)
         .subcommand(cmd_jamo_short_name)

--- a/src/bidi_mirroring_glyph.rs
+++ b/src/bidi_mirroring_glyph.rs
@@ -1,0 +1,30 @@
+use std::collections::BTreeMap;
+
+use ucd_parse::{self, BidiMirroring};
+
+use args::ArgMatches;
+use error::Result;
+
+pub fn command(args: ArgMatches) -> Result<()> {
+    let dir = args.ucd_dir()?;
+    let rows: Vec<BidiMirroring> = ucd_parse::parse(&dir)?;
+
+    let table: BTreeMap<_, _> = rows
+        .into_iter()
+        .map(|mapping| {
+            (
+                mapping.codepoint.value(),
+                mapping.bidi_mirroring_glyph.value(),
+            )
+        })
+        .collect();
+
+    let mut wtr = args.writer("bidi_mirroring_glyph")?;
+    if args.is_present("rust-match") {
+        wtr.codepoint_to_codepoint_fn(args.name(), &table)?;
+    } else {
+        wtr.codepoint_to_codepoint(args.name(), &table)?;
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ mod util;
 mod writer;
 
 mod age;
+mod bidi_mirroring_glyph;
 mod case_folding;
 mod general_category;
 mod brk;
@@ -50,6 +51,9 @@ fn main() {
 fn run() -> Result<()> {
     let matches = app::app().get_matches();
     match matches.subcommand() {
+        ("bidi-mirroring-glyph", Some(m)) => {
+            bidi_mirroring_glyph::command(ArgMatches::new(m))
+        }
         ("general-category", Some(m)) => {
             general_category::command(ArgMatches::new(m))
         }

--- a/src/property_bool.rs
+++ b/src/property_bool.rs
@@ -2,7 +2,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use ucd_parse::{
-    self, CoreProperty, EmojiProperty, Property, UnicodeDataExpander,
+    self, CoreProperty, EmojiProperty, Property, UcdFileByCodepoint, UnicodeData,
+    UnicodeDataExpander,
 };
 
 use args::ArgMatches;
@@ -78,6 +79,16 @@ fn parse_properties<P: AsRef<Path>>(
             .or_insert(BTreeSet::new())
             .extend(x.codepoints.into_iter().map(|c| c.value()));
     }
+
+    // Add Bidi_Mirrored
+    let unicode_data: Vec<UnicodeData> = ucd_parse::parse(&ucd_dir)?;
+    let bidi_mirrored = unicode_data.iter().fold(BTreeSet::new(), |mut set, x| {
+        if x.bidi_mirrored {
+            set.extend(x.codepoints().into_iter().map(|c| c.value()))
+        }
+        set
+    });
+    by_name.insert("Bidi_Mirrored".to_string(), bidi_mirrored);
 
     // Since emoji-data.txt isn't parse of the normal UCD download, don't
     // die if it doesn't exist. But emit a helpful warning message.

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -442,6 +442,38 @@ impl Writer {
         Ok(())
     }
 
+    /// Write a function that associates codepoints with other codepoints.
+    ///
+    /// The function will use a match expression to map between codepoints.
+    /// The fallback branch of the match returns 0.
+    pub fn codepoint_to_codepoint_fn(
+        &mut self,
+        name: &str,
+        map: &BTreeMap<u32, u32>,
+    ) -> Result<()> {
+        self.header()?;
+        self.separator()?;
+
+        let fn_name = rust_fn_name(name);
+        writeln!(self.wtr, "pub fn {}(cp: u32) -> u32 {{", fn_name)?;
+        self.wtr.indent("    ");
+        self.wtr.write_str("match cp {")?;
+        self.wtr.flush_line()?;
+        self.wtr.indent("        ");
+        for (from, to) in map {
+            self.wtr.write_str(&format!("{} => {},", from, to))?;
+            self.wtr.flush_line()?;
+        }
+        self.wtr.write_str("_ => 0,")?;
+        self.wtr.flush_line()?;
+        self.wtr.indent("    ");
+        self.wtr.write_str("}")?;
+        self.wtr.flush_line()?;
+        writeln!(self.wtr, "}}")?;
+        self.wtr.flush()?;
+        Ok(())
+    }
+
     /// Write a map that associates codepoints with other codepoints, where
     /// each codepoint can be associated with possibly many other codepoints.
     ///
@@ -1061,6 +1093,14 @@ fn rust_module_name(s: &str) -> String {
     let mut s = s.to_string();
     s.make_ascii_lowercase();
     s
+}
+
+fn rust_fn_name(s: &str) -> String {
+    // Convert to snake_case
+    s.to_ascii_lowercase()
+        .chars()
+        .map(|c| if c.is_whitespace() || c == '.' || c == '-' { '_' } else { c })
+        .collect()
 }
 
 /// Return the unsigned integer type for the size of the given type, which must

--- a/ucd-parse/src/bidi_mirroring_glyph.rs
+++ b/ucd-parse/src/bidi_mirroring_glyph.rs
@@ -1,0 +1,105 @@
+use std::fmt;
+use std::path::Path;
+use std::str::FromStr;
+
+use regex::Regex;
+
+use common::{Codepoint, CodepointIter, UcdFile, UcdFileByCodepoint};
+use error::Error;
+
+/// Represents a single row in the `BidiMirroring.txt` file.
+///
+/// The field names were taken from the header of BidiMirroring.txt.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct BidiMirroring {
+    /// The codepoint corresponding to this row.
+    pub codepoint: Codepoint,
+    /// The codepoint that has typically has a glyph that is the mirror image of `codepoint`.
+    pub bidi_mirroring_glyph: Codepoint,
+}
+
+impl UcdFile for BidiMirroring {
+    fn relative_file_path() -> &'static Path {
+        Path::new("BidiMirroring.txt")
+    }
+}
+
+impl UcdFileByCodepoint for BidiMirroring {
+    fn codepoints(&self) -> CodepointIter {
+        self.codepoint.into_iter()
+    }
+}
+
+impl FromStr for BidiMirroring {
+    type Err = Error;
+
+    fn from_str(line: &str) -> Result<BidiMirroring, Error> {
+        lazy_static! {
+            static ref PARTS: Regex = Regex::new(
+                r"(?x)
+                ^
+                \s*(?P<codepoint>[A-F0-9]+)\s*;
+                \s*(?P<substitute_codepoint>[A-F0-9]+)
+                \s+
+                \#(?:.+)
+                $
+                "
+            )
+            .unwrap();
+        };
+        let caps = match PARTS.captures(line.trim()) {
+            Some(caps) => caps,
+            None => return err!("invalid BidiMirroring line"),
+        };
+
+        Ok(BidiMirroring {
+            codepoint: caps["codepoint"].parse()?,
+            bidi_mirroring_glyph: caps["substitute_codepoint"].parse()?,
+        })
+    }
+}
+
+impl fmt::Display for BidiMirroring {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{};", self.codepoint)?;
+        write!(f, "{};", self.bidi_mirroring_glyph)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use common::Codepoint;
+
+    use super::BidiMirroring;
+
+    fn codepoint(n: u32) -> Codepoint {
+        Codepoint::from_u32(n).unwrap()
+    }
+
+    #[test]
+    fn parse() {
+        let line = "0028; 0029 # LEFT PARENTHESIS\n";
+        let data: BidiMirroring = line.parse().unwrap();
+        assert_eq!(
+            data,
+            BidiMirroring {
+                codepoint: codepoint(0x0028),
+                bidi_mirroring_glyph: codepoint(0x0029),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_best_fit() {
+        let line = "228A; 228B # [BEST FIT] SUBSET OF WITH NOT EQUAL TO\n";
+        let data: BidiMirroring = line.parse().unwrap();
+        assert_eq!(
+            data,
+            BidiMirroring {
+                codepoint: codepoint(0x228A),
+                bidi_mirroring_glyph: codepoint(0x228B),
+            }
+        );
+    }
+}

--- a/ucd-parse/src/lib.rs
+++ b/ucd-parse/src/lib.rs
@@ -16,6 +16,7 @@ pub use common::{
 pub use error::{Error, ErrorKind};
 
 pub use age::Age;
+pub use bidi_mirroring_glyph::BidiMirroring;
 pub use case_folding::{CaseFold, CaseStatus};
 pub use core_properties::CoreProperty;
 pub use emoji_properties::EmojiProperty;
@@ -49,6 +50,7 @@ mod common;
 mod error;
 
 mod age;
+mod bidi_mirroring_glyph;
 mod case_folding;
 mod core_properties;
 mod emoji_properties;


### PR DESCRIPTION
This PR:

* exposes `Bidi_Mirrored` in the `property-bool` command
* Adds support for parsing `BidiMirroring.txt` to `ucd-parse`
* Adds a `bidi-mirroring-glyph` sub-command for generating a bidi_mirroring_glyph as a Rust `match` expression.

Given the small number of entries in this table support for generating a `match` expression was added. Benchmarks showed that is was faster than binary searching the normally generated table and relatively compact (2.7KiB).

```
Bidi_Mirror/Binary Search/paragraph
                        time:   [7.4551 us 7.4575 us 7.4599 us]

Bidi_Mirror/match/paragraph
                        time:   [3.2717 us 3.2791 us 3.2884 us]
```

ASM of the match if you're curious (it appears to build a lookup table): https://gist.github.com/wezm/ec5ba4fc9b37b12fe3753f86fe282409

Sample output from `bidi-mirroring-glyph`:

```rust
// DO NOT EDIT THIS FILE. IT WAS AUTOMATICALLY GENERATED BY:
//
//  ucd-generate bidi-mirroring-glyph --rust-match /home/wmoore/Downloads/ucd-9
//
// ucd-generate is available on crates.io.

pub fn bidi_mirroring_glyph(cp: u32) -> u32 {
    match cp {
        40 => 41,
        41 => 40,
        60 => 62,
        62 => 60,
        91 => 93,
        93 => 91,
        123 => 125,
        125 => 123,
        171 => 187,
        187 => 171,
        ⋮
        65379 => 65378,
        _ => 0,
    }
}
```

Sample output from `property-bool --include Bidi_Mirrored`

```rust
// DO NOT EDIT THIS FILE. IT WAS AUTOMATICALLY GENERATED BY:
//
//  ucd-generate property-bool --include Bidi_Mirrored --trie-set /home/wmoore/Downloads/ucd-12.1
//
// ucd-generate is available on crates.io.

pub const BY_NAME: &'static [(&'static str, &'static ::ucd_trie::TrieSet)] = &[
  ("Bidi_Mirrored", BIDI_MIRRORED),
];

pub const BIDI_MIRRORED: &'static ::ucd_trie::TrieSet = &::ucd_trie::TrieSet {
  tree1_level1: &[
    0x5000030000000000, 0x2800000028000000, 0x800080000000000, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
  ],
  tree2_level1: &[
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
    ⋮
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 5, 0, 0, 0, 0,
    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
    0, 0, 0,
  ],
  tree3_level3: &[
    0, 0x8000000, 0x200000, 0x8000, 0x200, 0x8,
  ],
};
```